### PR TITLE
flathub: build only on x86_64

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,3 @@
 {
-  "skip-arches": ["arm"]
+  "only-arches": ["x86_64"]
 }


### PR DESCRIPTION
That's the only arch actually tested and supported so far.